### PR TITLE
Revert "Update appcast_test.xml"

### DIFF
--- a/appcast_test.xml
+++ b/appcast_test.xml
@@ -15,9 +15,9 @@
                     sparkle:os="ios"/>
         </item>
         <item>
-            <title>Version 1.6.43</title>
+            <title>Version 1.5.41</title>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
-            <sparkle:version>1.6.43</sparkle:version>
+            <sparkle:version>1.5.41</sparkle:version>
             <enclosure url="https://play.google.com/store/apps/details?id=com.fennel.app"
                        sparkle:os="android"/>
             <enclosure


### PR DESCRIPTION
Reverts fennelmarkets/fennel_appcast#29
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts version update in `appcast_test.xml` from 1.6.43 back to 1.5.41.
> 
>   - Reverts version update in `appcast_test.xml` from 1.6.43 back to 1.5.41.
>   - Affects `<title>` and `<sparkle:version>` elements for the reverted item.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fennelmarkets%2Ffennel_appcast&utm_source=github&utm_medium=referral)<sup> for abb067c5c6329e3837e341cb41489fbf3b8bc4b6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->