### PR TITLE
Force all users to current version (1.6.46)

### DIFF
--- a/appcast_prod.xml
+++ b/appcast_prod.xml
@@ -6,8 +6,8 @@
         <language>en-us</language>
         <!-- Suggested update -->
         <item>
-            <title>Version 1.6.41</title>
-            <sparkle:version>1.6.41</sparkle:version>
+            <title>Version 1.6.46</title>
+            <sparkle:version>1.6.46</sparkle:version>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
             <enclosure url="https://play.google.com/store/apps/details?id=com.fennel.app"
                        sparkle:os="android"/>
@@ -17,8 +17,8 @@
         </item>
         <!-- Forced update -->
         <item>
-            <title>Version 1.6.41</title>
-            <sparkle:version>1.6.41</sparkle:version>
+            <title>Version 1.6.46</title>
+            <sparkle:version>1.6.46</sparkle:version>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
             <enclosure url="https://play.google.com/store/apps/details?id=com.fennel.app"
                        sparkle:os="android"/>

--- a/appcast_test.xml
+++ b/appcast_test.xml
@@ -6,9 +6,9 @@
         <language>en-us</language>
         <!-- Suggested update -->
         <item>
-            <title>Version 1.6.42</title>
+            <title>Version 1.6.46</title>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
-            <sparkle:version>1.6.42</sparkle:version>
+            <sparkle:version>1.6.45</sparkle:version>
             <enclosure url="https://play.google.com/store/apps/details?id=com.fennel.app"
                        sparkle:os="android"/>
             <enclosure
@@ -17,9 +17,9 @@
         </item>
         <!-- Forced update -->
         <item>
-            <title>Version 1.6.42</title>
+            <title>Version 1.6.46</title>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
-            <sparkle:version>1.6.42</sparkle:version>
+            <sparkle:version>1.6.46</sparkle:version>
             <enclosure url="https://play.google.com/store/apps/details?id=com.fennel.app"
                        sparkle:os="android"/>
             <enclosure


### PR DESCRIPTION
This clears the way to making `account` return a Union of regular brokerage accounts and IRAs.