### PR TITLE
Bump app version to 1.6.50

### DIFF
--- a/prod/appcast_android_prod.xml
+++ b/prod/appcast_android_prod.xml
@@ -6,16 +6,16 @@
         <language>en-us</language>
         <!-- Suggested update -->
         <item>
-            <title>Version 1.6.46</title>
-            <sparkle:version>1.6.46</sparkle:version>
+            <title>Version 1.6.50</title>
+            <sparkle:version>1.6.50</sparkle:version>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
             <enclosure url="https://play.google.com/store/apps/details?id=com.fennel.app"
                        sparkle:os="android"/>
         </item>
         <!-- Forced update -->
         <item>
-            <title>Version 1.6.46</title>
-            <sparkle:version>1.6.46</sparkle:version>
+            <title>Version 1.6.50</title>
+            <sparkle:version>1.6.50</sparkle:version>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
             <enclosure url="https://play.google.com/store/apps/details?id=com.fennel.app"
                        sparkle:os="android"/>

--- a/prod/appcast_ios_prod.xml
+++ b/prod/appcast_ios_prod.xml
@@ -6,8 +6,8 @@
         <language>en-us</language>
         <!-- Suggested update -->
         <item>
-            <title>Version 1.6.46</title>
-            <sparkle:version>1.6.46</sparkle:version>
+            <title>Version 1.6.50</title>
+            <sparkle:version>1.6.50</sparkle:version>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
             <enclosure
                     url="https://apps.apple.com/us/app/fennel-esg-stocks-etfs/id6443565903"
@@ -15,8 +15,8 @@
         </item>
         <!-- Forced update -->
         <item>
-            <title>Version 1.6.46</title>
-            <sparkle:version>1.6.46</sparkle:version>
+            <title>Version 1.6.50</title>
+            <sparkle:version>1.6.50</sparkle:version>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
             <enclosure
                     url="https://apps.apple.com/us/app/fennel-esg-stocks-etfs/id6443565903"

--- a/test/appcast_android_test.xml
+++ b/test/appcast_android_test.xml
@@ -6,16 +6,16 @@
         <language>en-us</language>
         <!-- Suggested update -->
         <item>
-            <title>Version 1.6.46</title>
-            <sparkle:version>1.6.46</sparkle:version>
+            <title>Version 1.6.50</title>
+            <sparkle:version>1.6.50</sparkle:version>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
             <enclosure url="https://play.google.com/store/apps/details?id=com.fennel.app"
                        sparkle:os="android"/>
         </item>
         <!-- Forced update -->
         <item>
-            <title>Version 1.6.46</title>
-            <sparkle:version>1.6.46</sparkle:version>
+            <title>Version 1.6.50</title>
+            <sparkle:version>1.6.50</sparkle:version>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
             <enclosure url="https://play.google.com/store/apps/details?id=com.fennel.app"
                        sparkle:os="android"/>

--- a/test/appcast_ios_test.xml
+++ b/test/appcast_ios_test.xml
@@ -6,8 +6,8 @@
         <language>en-us</language>
         <!-- Suggested update -->
         <item>
-            <title>Version 1.6.46</title>
-            <sparkle:version>1.6.46</sparkle:version>
+            <title>Version 1.6.50</title>
+            <sparkle:version>1.6.50</sparkle:version>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
             <enclosure
                     url="https://apps.apple.com/us/app/fennel-esg-stocks-etfs/id6443565903"
@@ -15,8 +15,8 @@
         </item>
         <!-- Forced update -->
         <item>
-            <title>Version 1.6.46</title>
-            <sparkle:version>1.6.46</sparkle:version>
+            <title>Version 1.6.50</title>
+            <sparkle:version>1.6.50</sparkle:version>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
             <enclosure
                     url="https://apps.apple.com/us/app/fennel-esg-stocks-etfs/id6443565903"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Bump app version from 1.6.46 to 1.6.50 in Android and iOS appcast XML files for both production and test environments.
> 
>   - **Version Update**:
>     - Bump version from `1.6.46` to `1.6.50` in `prod/appcast_android_prod.xml`, `prod/appcast_ios_prod.xml`, `test/appcast_android_test.xml`, and `test/appcast_ios_test.xml`.
>     - Update both suggested and forced update items to reflect new version.
>   - **Files Affected**:
>     - `prod/appcast_android_prod.xml`
>     - `prod/appcast_ios_prod.xml`
>     - `test/appcast_android_test.xml`
>     - `test/appcast_ios_test.xml`
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fennelmarkets%2Ffennel_appcast&utm_source=github&utm_medium=referral)<sup> for 722c075c471b1146f0b860d14e56aeb613f8cda9. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->