### PR TITLE
Update appcast_android_test.xml

### DIFF
--- a/test/appcast_android_test.xml
+++ b/test/appcast_android_test.xml
@@ -6,16 +6,16 @@
         <language>en-us</language>
         <!-- Suggested update -->
         <item>
-            <title>Version 1.6.50</title>
-            <sparkle:version>1.6.50</sparkle:version>
+            <title>Version 1.6.48</title>
+            <sparkle:version>1.6.48</sparkle:version>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
             <enclosure url="https://play.google.com/store/apps/details?id=com.fennel.app"
                        sparkle:os="android"/>
         </item>
         <!-- Forced update -->
         <item>
-            <title>Version 1.6.50</title>
-            <sparkle:version>1.6.50</sparkle:version>
+            <title>Version 1.6.48</title>
+            <sparkle:version>1.6.48</sparkle:version>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
             <enclosure url="https://play.google.com/store/apps/details?id=com.fennel.app"
                        sparkle:os="android"/>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Rollback version from 1.6.50 to 1.6.48 in `test/appcast_android_test.xml` for suggested and forced updates.
> 
>   - **Version Rollback**:
>     - Rollback version from `1.6.50` to `1.6.48` in `test/appcast_android_test.xml`.
>     - Affects both suggested and forced update `<item>` entries.
>     - Changes `title` and `sparkle:version` elements.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fennelmarkets%2Ffennel_appcast&utm_source=github&utm_medium=referral)<sup> for 6d33fe25d4b7c0489a458d1b5acee4d893ef6909. You can [customize](https://app.ellipsis.dev/fennelmarkets/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->