### PR TITLE
Downgrade ios app version to 1.6.56 in production appcast files

### DIFF
--- a/appcast_prod.xml
+++ b/appcast_prod.xml
@@ -6,8 +6,8 @@
         <language>en-us</language>
         <!-- Suggested update -->
         <item>
-            <title>Version 1.6.57</title>
-            <sparkle:version>1.6.57</sparkle:version>
+            <title>Version 1.6.56</title>
+            <sparkle:version>1.6.56</sparkle:version>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
             <enclosure url="https://play.google.com/store/apps/details?id=com.fennel.app"
                        sparkle:os="android"/>
@@ -17,8 +17,8 @@
         </item>
         <!-- Forced update -->
         <item>
-            <title>Version 1.6.57</title>
-            <sparkle:version>1.6.57</sparkle:version>
+            <title>Version 1.6.56</title>
+            <sparkle:version>1.6.56</sparkle:version>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
             <enclosure url="https://play.google.com/store/apps/details?id=com.fennel.app"
                        sparkle:os="android"/>

--- a/prod/appcast_ios_prod.xml
+++ b/prod/appcast_ios_prod.xml
@@ -6,8 +6,8 @@
         <language>en-us</language>
         <!-- Suggested update -->
         <item>
-            <title>Version 1.6.57</title>
-            <sparkle:version>1.6.57</sparkle:version>
+            <title>Version 1.6.56</title>
+            <sparkle:version>1.6.56</sparkle:version>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
             <enclosure
                     url="https://apps.apple.com/us/app/fennel-esg-stocks-etfs/id6443565903"
@@ -15,8 +15,8 @@
         </item>
         <!-- Forced update -->
         <item>
-            <title>Version 1.6.57</title>
-            <sparkle:version>1.6.57</sparkle:version>
+            <title>Version 1.6.56</title>
+            <sparkle:version>1.6.56</sparkle:version>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
             <enclosure
                     url="https://apps.apple.com/us/app/fennel-esg-stocks-etfs/id6443565903"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Downgrade iOS app version from 1.6.57 to 1.6.56 in production appcast files for both suggested and forced updates.
> 
>   - **Version Downgrade**:
>     - Downgrade iOS app version from `1.6.57` to `1.6.56` in `appcast_prod.xml` and `prod/appcast_ios_prod.xml`.
>     - Affects both suggested and forced updates in both files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fennelmarkets%2Ffennel_appcast&utm_source=github&utm_medium=referral)<sup> for 9edc094ba8ff8f99461f7b712e3ed1ba72d066c3. You can [customize](https://app.ellipsis.dev/fennelmarkets/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->