### PR TITLE
Force app version to 1.6.60

### DIFF
--- a/appcast_prod.xml
+++ b/appcast_prod.xml
@@ -6,8 +6,8 @@
         <language>en-us</language>
         <!-- Suggested update -->
         <item>
-            <title>Version 1.6.56</title>
-            <sparkle:version>1.6.56</sparkle:version>
+            <title>Version 1.6.60</title>
+            <sparkle:version>1.6.60</sparkle:version>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
             <enclosure url="https://play.google.com/store/apps/details?id=com.fennel.app"
                        sparkle:os="android"/>
@@ -17,8 +17,8 @@
         </item>
         <!-- Forced update -->
         <item>
-            <title>Version 1.6.56</title>
-            <sparkle:version>1.6.56</sparkle:version>
+            <title>Version 1.6.60</title>
+            <sparkle:version>1.6.60</sparkle:version>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
             <enclosure url="https://play.google.com/store/apps/details?id=com.fennel.app"
                        sparkle:os="android"/>

--- a/appcast_test.xml
+++ b/appcast_test.xml
@@ -6,9 +6,9 @@
         <language>en-us</language>
         <!-- Suggested update -->
         <item>
-            <title>Version 1.6.50</title>
+            <title>Version 1.6.60</title>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
-            <sparkle:version>1.6.50</sparkle:version>
+            <sparkle:version>1.6.60</sparkle:version>
             <enclosure url="https://play.google.com/store/apps/details?id=com.fennel.app"
                        sparkle:os="android"/>
             <enclosure
@@ -17,9 +17,9 @@
         </item>
         <!-- Forced update -->
         <item>
-            <title>Version 1.6.50</title>
+            <title>Version 1.6.60</title>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
-            <sparkle:version>1.6.50</sparkle:version>
+            <sparkle:version>1.6.60</sparkle:version>
             <enclosure url="https://play.google.com/store/apps/details?id=com.fennel.app"
                        sparkle:os="android"/>
             <enclosure

--- a/prod/appcast_android_prod.xml
+++ b/prod/appcast_android_prod.xml
@@ -6,16 +6,16 @@
         <language>en-us</language>
         <!-- Suggested update -->
         <item>
-            <title>Version 1.6.57</title>
-            <sparkle:version>1.6.57</sparkle:version>
+            <title>Version 1.6.60</title>
+            <sparkle:version>1.6.60</sparkle:version>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
             <enclosure url="https://play.google.com/store/apps/details?id=com.fennel.app"
                        sparkle:os="android"/>
         </item>
         <!-- Forced update -->
         <item>
-            <title>Version 1.6.57</title>
-            <sparkle:version>1.6.57</sparkle:version>
+            <title>Version 1.6.60</title>
+            <sparkle:version>1.6.60</sparkle:version>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
             <enclosure url="https://play.google.com/store/apps/details?id=com.fennel.app"
                        sparkle:os="android"/>

--- a/prod/appcast_ios_prod.xml
+++ b/prod/appcast_ios_prod.xml
@@ -6,8 +6,8 @@
         <language>en-us</language>
         <!-- Suggested update -->
         <item>
-            <title>Version 1.6.56</title>
-            <sparkle:version>1.6.56</sparkle:version>
+            <title>Version 1.6.60</title>
+            <sparkle:version>1.6.60</sparkle:version>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
             <enclosure
                     url="https://apps.apple.com/us/app/fennel-esg-stocks-etfs/id6443565903"
@@ -15,8 +15,8 @@
         </item>
         <!-- Forced update -->
         <item>
-            <title>Version 1.6.56</title>
-            <sparkle:version>1.6.56</sparkle:version>
+            <title>Version 1.6.60</title>
+            <sparkle:version>1.6.60</sparkle:version>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
             <enclosure
                     url="https://apps.apple.com/us/app/fennel-esg-stocks-etfs/id6443565903"

--- a/test/appcast_android_test.xml
+++ b/test/appcast_android_test.xml
@@ -6,16 +6,16 @@
         <language>en-us</language>
         <!-- Suggested update -->
         <item>
-            <title>Version 1.6.48</title>
-            <sparkle:version>1.6.48</sparkle:version>
+            <title>Version 1.6.60</title>
+            <sparkle:version>1.6.60</sparkle:version>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
             <enclosure url="https://play.google.com/store/apps/details?id=com.fennel.app"
                        sparkle:os="android"/>
         </item>
         <!-- Forced update -->
         <item>
-            <title>Version 1.6.48</title>
-            <sparkle:version>1.6.48</sparkle:version>
+            <title>Version 1.6.60</title>
+            <sparkle:version>1.6.60</sparkle:version>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
             <enclosure url="https://play.google.com/store/apps/details?id=com.fennel.app"
                        sparkle:os="android"/>

--- a/test/appcast_ios_test.xml
+++ b/test/appcast_ios_test.xml
@@ -6,8 +6,8 @@
         <language>en-us</language>
         <!-- Suggested update -->
         <item>
-            <title>Version 1.6.50</title>
-            <sparkle:version>1.6.50</sparkle:version>
+            <title>Version 1.6.60</title>
+            <sparkle:version>1.6.60</sparkle:version>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
             <enclosure
                     url="https://apps.apple.com/us/app/fennel-esg-stocks-etfs/id6443565903"
@@ -15,8 +15,8 @@
         </item>
         <!-- Forced update -->
         <item>
-            <title>Version 1.6.50</title>
-            <sparkle:version>1.6.50</sparkle:version>
+            <title>Version 1.6.60</title>
+            <sparkle:version>1.6.60</sparkle:version>
             <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
             <enclosure
                     url="https://apps.apple.com/us/app/fennel-esg-stocks-etfs/id6443565903"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update app version to 1.6.60 in appcast files for both Android and iOS, including critical update tags for forced updates.
> 
>   - **Version Update**:
>     - Update app version to `1.6.60` in `appcast_prod.xml`, `appcast_test.xml`, `prod/appcast_android_prod.xml`, `prod/appcast_ios_prod.xml`, `test/appcast_android_test.xml`, and `test/appcast_ios_test.xml`.
>     - Applies to both suggested and forced updates.
>   - **Critical Update**:
>     - Add `<sparkle:criticalUpdate/>` tag for forced updates in all files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fennelmarkets%2Ffennel_appcast&utm_source=github&utm_medium=referral)<sup> for 73c11658b83b8cea5e0cc0fb78da4469f5e73a40. You can [customize](https://app.ellipsis.dev/fennelmarkets/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->